### PR TITLE
Updated libxml2 to version 2.9.10 (latest) [GDSN-998]

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,22 +18,11 @@ spec = Gem::Specification.load("#{GEM_NAME}.gemspec")
 task :default => [:test]
 
 # Setup compile tasks
-if RUBY_PLATFORM.match(/mswin32|mswin64|mingw32/)
-  Rake::ExtensionTask.new do |ext|
-    ext.gem_spec = spec
-    ext.name = SO_NAME
-    ext.ext_dir = "ext/libxml"
-    ext.lib_dir = "lib/#{RUBY_VERSION.sub(/\.\d$/, '')}"
-    ext.config_options << "--with-xml2-include=C:/msys64/mingw64/include/libxml2"
-  end
-else
-  Rake::ExtensionTask.new do |ext|
-    ext.gem_spec = spec
-    ext.name = SO_NAME
-    ext.ext_dir = "ext/libxml"
-    ext.lib_dir = "lib/#{RUBY_VERSION.sub(/\.\d$/, '')}"
-    ext.config_options << "--with-xml2-include=/usr/include/libxml2"
-  end
+Rake::ExtensionTask.new do |ext|
+  ext.gem_spec = spec
+  ext.name = SO_NAME
+  ext.ext_dir = "ext/libxml"
+  ext.lib_dir = "lib/#{RUBY_VERSION.sub(/\.\d$/, '')}"
 end
 
 # Setup generic gem

--- a/ext/libxml/extconf.rb
+++ b/ext/libxml/extconf.rb
@@ -1,9 +1,13 @@
 #!/usr/bin/env ruby
 
 require 'mkmf'
+require 'rubygems'
+gem 'mini_portile2', '~> 2.5.0' # Keep this version in sync with the one in the gemspec!
+require 'mini_portile2'
+message "Using mini_portile2 version #{MiniPortile::VERSION}\n"
 
-LIBXML2_VERSION = '2.9.9'.freeze
-LIBXML2_SHA256 = '94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871'.freeze
+LIBXML2_VERSION = '2.9.10'.freeze
+LIBXML2_SHA256 = 'aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f'.freeze
 
 def darwin?
   RbConfig::CONFIG['target_os'] =~ /darwin/
@@ -13,13 +17,6 @@ def crash(str)
   puts(" extconf failure: #{str}")
   exit 1
 end
-
-# The gem version constraint in the Rakefile is not respected at install time.
-# Keep this version in sync with the one in the Rakefile !
-require 'rubygems'
-gem 'mini_portile2', '~> 2.4.0'
-require 'mini_portile2'
-message "Using mini_portile version #{MiniPortile::VERSION}\n"
 
 if darwin?
   have_header('iconv.h') || crash('missing iconv.h')
@@ -58,8 +55,6 @@ unless File.exist?(checkpoint)
   FileUtils.touch checkpoint
 end
 libxml2_recipe.activate
-# .activate is supposed to do this, but it doesn't
-$LIBPATH = ["#{libxml2_recipe.path}/lib"] | $LIBPATH
 append_cflags("-I#{File.join(libxml2_recipe.path, 'include', 'libxml2')}")
 
 have_header('libxml/parser.h') || crash('parser.h not found')

--- a/ext/libxml/extconf.rb
+++ b/ext/libxml/extconf.rb
@@ -2,7 +2,7 @@
 
 require 'mkmf'
 require 'rubygems'
-gem 'mini_portile2', '~> 2.5.0' # Keep this version in sync with the one in the gemspec!
+gem 'mini_portile2', '>= 2.4.0' # Keep this version in sync with the one in the gemspec!
 require 'mini_portile2'
 message "Using mini_portile2 version #{MiniPortile::VERSION}\n"
 
@@ -55,6 +55,8 @@ unless File.exist?(checkpoint)
   FileUtils.touch checkpoint
 end
 libxml2_recipe.activate
+# .activate is supposed to do this, but it doesn't before mini_portile2-2.5.0, can be removed once we update.
+$LIBPATH = ["#{libxml2_recipe.path}/lib"] | $LIBPATH
 append_cflags("-I#{File.join(libxml2_recipe.path, 'include', 'libxml2')}")
 
 have_header('libxml/parser.h') || crash('parser.h not found')

--- a/salsify_libxml_ruby.gemspec
+++ b/salsify_libxml_ruby.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.test_files = Dir.glob('test/test_*.rb')
   spec.required_ruby_version = '>= 2.5'
+  spec.add_runtime_dependency("mini_portile2", "~> 2.5.0") # keep version in sync with the one in extconf.rb
   spec.add_development_dependency 'salsify_gem'
   spec.add_development_dependency 'rake-compiler'
   spec.add_development_dependency 'minitest'

--- a/salsify_libxml_ruby.gemspec
+++ b/salsify_libxml_ruby.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.test_files = Dir.glob('test/test_*.rb')
   spec.required_ruby_version = '>= 2.5'
-  spec.add_runtime_dependency("mini_portile2", "~> 2.5.0") # keep version in sync with the one in extconf.rb
+  spec.add_runtime_dependency("mini_portile2", ">= 2.4.0") # keep version in sync with the one in extconf.rb
   spec.add_development_dependency 'salsify_gem'
   spec.add_development_dependency 'rake-compiler'
   spec.add_development_dependency 'minitest'


### PR DESCRIPTION
Running `rake test` gives 3 errors and 1 failure, but this is better than the `libxml-ruby` CI which segfaults.
