### PR TITLE
[GDSN-2503] Add methods to read the minOccurs and maxOccurs attributes

### DIFF
--- a/ext/libxml/ruby_xml_version.h
+++ b/ext/libxml/ruby_xml_version.h
@@ -1,8 +1,8 @@
 /* Don't nuke this block!  It is used for automatically updating the
  * versions below. VERSION = string formatting, VERNUM = numbered
  * version for inline testing: increment both or none at all.*/
-#define RUBY_LIBXML_VERSION  "3.2.1.2"
-#define RUBY_LIBXML_VERNUM   3212
+#define RUBY_LIBXML_VERSION  "3.2.1.3"
+#define RUBY_LIBXML_VERNUM   3213
 #define RUBY_LIBXML_VER_MAJ   3
 #define RUBY_LIBXML_VER_MIN   2
 #define RUBY_LIBXML_VER_MIC   1

--- a/lib/libxml/schema/element.rb
+++ b/lib/libxml/schema/element.rb
@@ -14,6 +14,14 @@ module LibXML
       def elements
         type.elements
       end
+
+      def min_occurs
+        @min
+      end
+
+      def max_occurs
+        @max
+      end
     end
   end
 end


### PR DESCRIPTION
# Problem

[JIRA ticket](https://salsify.atlassian.net/browse/GDSN-2503)

Our wrapper does not expose any methods to get the `minOccurs` and `maxOccurs` attributes of XML elements.

# Solution

Add a `min_occurs` and `max_occurs` methods to the `Schema::Element` class.